### PR TITLE
Looper should trap SIGINT

### DIFF
--- a/lib/thor_repl/looper.rb
+++ b/lib/thor_repl/looper.rb
@@ -8,6 +8,8 @@ module ThorRepl
     end
 
     def run
+      Signal.trap("INT", method(:sigint_handler))
+
       puts "Welcome to interactive mode. Use 'help' to list available commands" if @welcome_message
 
       repl(-> () { @readline_class.readline(@prompt, true) }) do |input|
@@ -17,6 +19,10 @@ module ThorRepl
     end
 
     private
+
+    def sigint_handler(*args)
+      print "^C\n#{@prompt}"
+    end
 
     def repl(input_proc)
       while (input = input_proc.call)

--- a/spec/thor_repl/looper_spec.rb
+++ b/spec/thor_repl/looper_spec.rb
@@ -1,4 +1,4 @@
-require 'readline'
+require "readline"
 
 RSpec.describe ThorRepl::Looper do
   class FakeReadLine
@@ -15,12 +15,24 @@ RSpec.describe ThorRepl::Looper do
   describe "instance methods" do
     let(:thor_class) { double(:thor_class) }
     let(:readline_class) { FakeReadLine.new(input) }
-    let(:repl) { described_class.new(thor_commands_class: thor_class, readline_class: readline_class, welcome_message: false) }
-
+    let(:repl) do
+      described_class.new(
+        thor_commands_class: thor_class,
+        readline_class: readline_class,
+        welcome_message: false,
+      )
+    end
 
     describe "#run" do
       context "when prompt is set" do
-        let(:repl) { described_class.new(thor_commands_class: thor_class, prompt: "funky", readline_class: readline_class, welcome_message: false) }
+        let(:repl) do
+          described_class.new(
+            thor_commands_class: thor_class,
+            prompt: "funky",
+            readline_class: readline_class,
+            welcome_message: false,
+          )
+        end
         let(:input) { "exit" }
 
         it "passes the prompt to readline" do


### PR DESCRIPTION
Everybody knows that a good REPL is completely inscrutable and traps `^C` when an inexperienced user tries to kill the process instead of typing "exit" or `^D` like a greyhair.